### PR TITLE
Improve dependency scanning output

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,19 @@ Run the script:
 ```shell
 run.sh --type gradle --artifact slf4j-api gradle.txt
 ```
+
+## Output
+Once the script has been run, you will get an output similar to the following:
+
+```text
+The artifact with id 'slf4j-api' has been found in 2 dependencies:
+
+1. 'nohttp-cli-0.0.11.jar' has matches in:
+        - META-INF/maven/org.slf4j/slf4j-api/pom.properties
+
+2. 'slf4j-api-2.0.16.jar' has matches in:
+        - META-INF/MANIFEST.MF
+        - META-INF/maven/org.slf4j/slf4j-api/pom.properties
+```
+
+In this case the project had a direct dependency with `slf4j-api:2.0.16`, but it was also shaded in `nohttp-cli:0.0.11`

--- a/run.sh
+++ b/run.sh
@@ -103,7 +103,7 @@ cmd="$cmd $DOCKER_IMAGE ${args[*]}"
 echo "Analyzing '$type' dependencies in '$input'"
 eval "$cmd"
 if [ -s "$log" ]; then
-  >&2 echo "Log files are available at '$log'"
+  >&2 echo "Log file is available at '$log', please share it with Datadog for troubleshooting"
 else
    rm "$log"
 fi

--- a/sniffer.py
+++ b/sniffer.py
@@ -91,9 +91,15 @@ def _analyze_java_dependencies(args: Namespace):
 
     dependencies = dict()
     for item in result:
-        index = item.index("{")
-        parent_file = item[len(WORKSPACE) + 1: index]
-        children_ref = item[index + 1: -1]
+        start = item.find("{")
+        if start >= 0:
+            end = item.rfind("}")
+            parent_file = item[len(WORKSPACE) + 1: start]
+            children_ref = item[start + 1: end]
+        else:
+            # should not happen as we are dealing with nested jars
+            parent_file = item
+            children_ref = item
         children = dependencies.setdefault(parent_file, [])
         children.append(children_ref)
 


### PR DESCRIPTION
# What Does This Do
Improves the output of the tool to make it more human friendly:

From
```
The artifact with id 'slf4j-api' has been found in the following file(s):
{
    "nohttp-cli-0.0.11.jar": [
        "META-INF/maven/org.slf4j/slf4j-api/pom.properties"
    ],
    "slf4j-api-2.0.16.jar": [
        "META-INF/MANIFEST.MF",
        "META-INF/maven/org.slf4j/slf4j-api/pom.properties"
    ]
}
```

To
```
The artifact with id 'slf4j-api' has been found in 2 dependencies:

1. 'nohttp-cli-0.0.11.jar' has matches in:
        - META-INF/maven/org.slf4j/slf4j-api/pom.properties

2. 'slf4j-api-2.0.16.jar' has matches in:
        - META-INF/MANIFEST.MF
        - META-INF/maven/org.slf4j/slf4j-api/pom.properties

```

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-dependency-sniffer/blob/master/CONTRIBUTING.md#title-format)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.
-->
