### PR TITLE
Ensure we always pull the latest image when running the tool

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,11 +23,6 @@ print_usage() {
 
 test_command "docker" "follow the guide at https://docs.docker.com/engine/install/"
 
-if [ -f "$BASEDIR/Dockerfile" ]; then
-  echo "Building docker image"
-  docker build --quiet -t "$DOCKER_IMAGE" .
-fi
-
 args=()
 type=""
 input=""
@@ -57,7 +52,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-cmd="docker run --rm"
+if [ -f "$BASEDIR/Dockerfile" ]; then
+  echo "Building docker image"
+  docker build --quiet -t "$DOCKER_IMAGE" .
+  cmd="docker run --rm"
+else
+  cmd="docker run --pull=always --rm"
+fi
 
 # mount the source pointing to the dependencies
 if [ -z "$input" ]; then


### PR DESCRIPTION
# What Does This Do
Adds `--pull=always` to the docker run command to ensure we always use the latest version of the tool.

# Motivation

# Additional Notes

# Contributor Checklist

- [ ] Format the title [according the contribution guidelines](https://github.com/DataDog/dd-dependency-sniffer/blob/master/CONTRIBUTING.md#title-format)
- [ ] Squash your commits prior merging or merge using GitHub's [Squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
- [ ] Don't use `close`, `fix` or any [linking keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) when referencing an issue.

<!--
# Opening vs Drafting a PR:
When opening a pull request, please open it as a draft to not auto assign reviewers before you feel the pull request is in a reviewable state.
-->
